### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The private key is exposed to both the checkout and the command as an ssh-agent 
 steps:
   - command: ./run_build.sh
     plugins:
-      vault-secrets#v0.1.0:
-        server: my-vault-server
+      - vault-secrets#v0.1.0:
+          server: my-vault-server
 ```
 
 ## Uploading Secrets
@@ -124,10 +124,10 @@ Can be loaded using:
 steps:
   - command: ./run_build.sh
     plugins:
-      vault-secrets#v0.1.0:
-        server: my-vault-server
-        secrets:
-        - key
+      - vault-secrets#v0.1.0:
+          server: my-vault-server
+          secrets:
+          - key
 ```
 ## Options
 


### PR DESCRIPTION
Hi @mikeknox! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.